### PR TITLE
Fix word cloud terms truncation issue

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -72,7 +72,7 @@ class HTML:
 
         # save links into list
         for match in matchList:
-            match = match[13:][:-3]
+            match = match[13:][:-2]
             match = match.split('+')
             searchRaw.append(match)
         for word in list(itertools.chain.from_iterable(searchRaw)):


### PR DESCRIPTION
Fix the issue where the last character of last word in the search term array gets truncated.