### PR TITLE
Update takeout search directory to new format with YouTube music

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -9,6 +9,8 @@ import itertools
 missing=[]
 dir = os.path.join(os.getcwd(),"Takeout/YouTube/")
 if not os.path.exists(dir):
+    dir = os.path.join(os.getcwd(),"Takeout/YouTube and YouTube Music/")
+if not os.path.exists(dir):
 	missing.append(dir)
 found=False
 for path in ("Verlauf/Wiedergabeverlauf.html","history/watch-history.html"):	#translations


### PR DESCRIPTION
The new takeout format has changed the path for the Youtube data, it now includes Youtube music. I added this search path as a fallback in case the original one is not found.

Perhaps the original should be removed/replaced altogether since most users will use a fresh takeout.